### PR TITLE
Logging system redesign. EnvInfo made optional for Log method itself

### DIFF
--- a/src/Lykke.Common/Log/MicrosoftLoggingBasedLogExtensions.cs
+++ b/src/Lykke.Common/Log/MicrosoftLoggingBasedLogExtensions.cs
@@ -684,7 +684,7 @@ namespace Lykke.Common.Log
                 new LogEntryParameters(
                     AppEnvironment.Name,
                     AppEnvironment.Version,
-                    AppEnvironment.EnvInfo,
+                    AppEnvironment.EnvInfo ?? "?",
                     callerFilePath,
                     process,
                     callerLineNumber,


### PR DESCRIPTION
EnvInfo will be checked only on UseLykkeLogging. This is usable for tests.