### PR TITLE
Safe space chars trim implemented in string utils class.

### DIFF
--- a/src/Lykke.Common/StringUtils.cs
+++ b/src/Lykke.Common/StringUtils.cs
@@ -12,6 +12,9 @@ namespace Common
     [PublicAPI]
     public static class StringUtils
     {
+        // Is needed for TrimAllSpacesAroundNullSafe()
+        private static readonly char[] SpaceCharsArray = { ' ', '\t', '\n', '\r'};
+
         /// <summary>
         /// Calculates string 64 bit hash
         /// </summary>
@@ -670,6 +673,18 @@ namespace Common
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Returns a string without space characters at the begining and at the end. May be safely applied to null value input. Chars to remove are: ' ', '\t', '\n', '\r'.
+        /// </summary>
+        /// <param name="value">The input string. May be null.</param>
+        /// <returns>The trimmed string if not-null was given and an empty string otherwise.</returns>
+        public static string TrimAllSpacesAroundNullSafe(this string value)
+        {
+            return string.IsNullOrWhiteSpace(value)
+                ? string.Empty
+                : value.Trim(SpaceCharsArray);
         }
     }
 

--- a/tests/Common.Tests/UtilsClass/StringUtilsTests.cs
+++ b/tests/Common.Tests/UtilsClass/StringUtilsTests.cs
@@ -242,5 +242,34 @@ namespace Common.Tests.UtilsClass
             ip = "192.168.1.100";
             Assert.Equal("192.168.1.0", ip.SanitizeIp());
         }
+
+        [Fact]
+        public void Test_TrimAllSpacesAroundNullSafe()
+        {
+            // Arrange
+            string[] corruptedStrings =
+            {
+                "       \takbjviu\n\n\n\r\t     ",
+                "  \t\t         \n\r \r   ukanegvi",
+                "jbhver,u\n\n\n\r\t         \t       \n",
+                "iuqgbvb",
+                "bav    \r\n   \t    ubvrubv",
+                null
+            };
+
+            string[] correctedStrings =
+            {
+                "akbjviu",
+                "ukanegvi",
+                "jbhver,u",
+                "iuqgbvb",
+                "bav    \r\n   \t    ubvrubv",
+                string.Empty
+            };
+
+            // Act & Assert
+            for (var i = 0; i < corruptedStrings.Length; i++)
+                Assert.Equal(corruptedStrings[i].TrimAllSpacesAroundNullSafe(), correctedStrings[i]);
+        }
     }
 }


### PR DESCRIPTION
The new string extension method added for trimming all the possible space chars from around the string:
* null-safe;
* XML-doc included;
* a unit test included too.