### PR TITLE
Fix for getting Name and Version

### DIFF
--- a/src/Lykke.Common/AppEnvironment.cs
+++ b/src/Lykke.Common/AppEnvironment.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.Extensions.PlatformAbstractions;
 
@@ -18,11 +19,11 @@ namespace Lykke.Common
         /// <summary>
         /// Version of the app
         /// </summary>
-        public static string Version { get; } = PlatformServices.Default.Application.ApplicationVersion;
+        public static string Version { get; } = Assembly.GetEntryAssembly().GetName().Version.ToString();
 
         /// <summary>
         /// Name of the app
         /// </summary>
-        public static string Name { get; } = PlatformServices.Default.Application.ApplicationName;
+        public static string Name { get; } = Assembly.GetEntryAssembly().GetName().Name;
     }
 }


### PR DESCRIPTION
PlatformServices is already deprecated (https://github.com/aspnet/Announcements/issues/237) and not working for .net code 3.0 (preview) projects (https://github.com/dotnet/corefx/issues/35068) Used api suggested in https://github.com/aspnet/Announcements/issues/237